### PR TITLE
nav btn hover no longer pushes site down

### DIFF
--- a/styles/root.css
+++ b/styles/root.css
@@ -79,12 +79,13 @@ section {
   display: inline-block;
   margin-bottom: 1em;
   margin-top: 1em;
+  transition: transform 250ms;
 }
 
 .btn:hover, .btn:active {
   background-color: var(--extra-light-background);
   color: white;
-  padding: 10px 17px;
+  transform: scale(1.1);
 }
 
 .center-text {


### PR DESCRIPTION
I fixed the issue by scaling the button instead of adding padding to it. Adding padding causes the button to change its size, which increases the height of the container it is in. Scaling just scales an element without altering the flow of the layout
And btw, your `replace.py` script didn't work for me, I had to to `cp -r source output` to make it work